### PR TITLE
Add support for log level to be controlled via environment variable or command line argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ The server provides clear error messages for:
 - API errors
 - Rate limiting
 
+The `LOG_LEVEL` environment variable can be specified to control the verbosity of server logs. Valid values are `trace`, `debug`, `info`, `warn`, and `error` (default).
+This can be also be specified on the command line as, e.g. `--env LOG_LEVEL=info`.
+
 ## Support the Developer
 
 When using this server, you may occasionally see a small sponsor message with a link to this repository included in tool responses. I hope you can support the project!

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -29,8 +29,36 @@ export enum LogLevel {
   ERROR = 4,
 }
 
-// Fixed log level - always use TRACE as the minimum level for complete logging
-const configuredLevel = LogLevel.TRACE;
+// Parse LOG_LEVEL environment variable or command line argument
+const parseLogLevel = (levelStr: string | undefined): LogLevel => {
+  if (!levelStr) return LogLevel.ERROR; // Default to ERROR if not specified
+  
+  switch (levelStr.toUpperCase()) {
+    case 'trace': return LogLevel.TRACE;
+    case 'debug': return LogLevel.DEBUG;
+    case 'info': return LogLevel.INFO;
+    case 'warn': return LogLevel.WARN;
+    case 'error': return LogLevel.ERROR;
+    default:
+      console.error(`Invalid LOG_LEVEL: ${levelStr}, defaulting to ERROR`);
+      return LogLevel.ERROR;
+  }
+};
+
+// Parse command line arguments for LOG_LEVEL
+const args = process.argv.slice(2);
+let argLogLevel: string | undefined;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--env' && i + 1 < args.length) {
+    const [key, value] = args[i + 1].split('=');
+    if (key === 'LOG_LEVEL') argLogLevel = value;
+    i++;
+  }
+}
+
+// Get log level from environment variable or command line, default to ERROR
+const configuredLevel = parseLogLevel(argLogLevel || process.env.LOG_LEVEL);
+console.debug(`Log level set to: ${LogLevel[configuredLevel]}`);
 
 /**
  * Check if a log level is enabled based on the configured level


### PR DESCRIPTION
This adds support for LOG_LEVEL and sets the default to "error". It seems that having too verbose log messages causes issues for tools like Cline which monitor the output of the MCP server.

Fixes #17 

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Tool functionality (new tool, tool modification)
- [x] MCP integration improvement
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Documentation update
- [ ] API enhancements
- [ ] Security improvement

## MCP Server Impact
<!-- Describe how this change affects the MCP server behavior -->
It doe snot affect it other than the log output on the console.

## API Changes
<!-- Describe any changes to APIs (both ClickUp API interactions and Service layer) -->
No changes.

## Checklist
<!-- Mark the items you've completed with an "x" -->
- [x] My code follows the code style of this project
- [x] I have tested the changes
- [x] I've verified compatibility with MCP standards
- [x] All tool schemas are properly documented
- [x] Service layer changes are backward compatible (or documented if breaking)
- [x] Rate limiting and error handling tested (if applicable)
- [x] Security considerations addressed

## Testing
<!-- Describe how you tested your changes -->
Tested with Cline extension in VSCode.

## Documentation Updates
<!-- List any documentation updates needed -->
Added details for the new environment variable.