### PR TITLE
Fix log level

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -34,11 +34,11 @@ const parseLogLevel = (levelStr: string | undefined): LogLevel => {
   if (!levelStr) return LogLevel.ERROR; // Default to ERROR if not specified
   
   switch (levelStr.toUpperCase()) {
-    case 'trace': return LogLevel.TRACE;
-    case 'debug': return LogLevel.DEBUG;
-    case 'info': return LogLevel.INFO;
-    case 'warn': return LogLevel.WARN;
-    case 'error': return LogLevel.ERROR;
+    case 'TRACE': return LogLevel.TRACE;
+    case 'DEBUG': return LogLevel.DEBUG;
+    case 'INFO': return LogLevel.INFO;
+    case 'WARN': return LogLevel.WARN;
+    case 'ERROR': return LogLevel.ERROR;
     default:
       console.error(`Invalid LOG_LEVEL: ${levelStr}, defaulting to ERROR`);
       return LogLevel.ERROR;


### PR DESCRIPTION
Hey, sorry I made a mistake in the PR #18... This fixes it, tested this time with:

```
CLICKUP_API_KEY=... CLICKUP_TEAM_ID=... LOG_LEVEL=debug npx -y concurrently "npm run dev" "npx -y nodemon build/index.js"
```

And I can see the info log messages and the "Log level set to: DEBUG" message in the console.