### PR TITLE
update JSON schema for compatibility with windsurf

### DIFF
--- a/src/tools/task/bulk-operations.ts
+++ b/src/tools/task/bulk-operations.ts
@@ -216,7 +216,8 @@ export const updateBulkTasksTool = {
               description: "New status"
             },
             priority: {
-              type: ["number", "null"],
+              type: "number",
+              nullable: true,
               enum: [1, 2, 3, 4, null],
               description: "New priority (1-4 or null)"
             },

--- a/src/tools/task/single-operations.ts
+++ b/src/tools/task/single-operations.ts
@@ -187,7 +187,8 @@ export const updateTaskTool = {
         description: "New status. Must be valid for the task's current list."
       },
       priority: {
-        type: ["number", "null"],
+        type: "number",
+        nullable: true,
         enum: [1, 2, 3, 4, null],
         description: "New priority: 1 (urgent) to 4 (low). Set null to clear priority."
       },


### PR DESCRIPTION

# Pull Request

## Description
Fixed JSON schema type definitions in task tools to use single string type with nullable property instead of array types. This resolves parsing errors in the windsurf Go parser which cannot unmarshal array types into Go struct fields expecting string values.

Affected tools:
- update_task
- update_bulk_tasks

## Related Issue
<!-- Link to the issue this PR addresses (if applicable) -->
Fixes #

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Tool functionality (new tool, tool modification)
- [x] MCP integration improvement
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Documentation update
- [ ] API enhancements
- [ ] Security improvement

## MCP Server Impact
<!-- Describe how this change affects the MCP server behavior -->

## API Changes
<!-- Describe any changes to APIs (both ClickUp API interactions and Service layer) -->

## Checklist
<!-- Mark the items you've completed with an "x" -->
- [x] My code follows the code style of this project
- [x] I have tested the changes
- [ ] I've verified compatibility with MCP standards
- [x] All tool schemas are properly documented
- [x] Service layer changes are backward compatible (or documented if breaking)
- [ ] Rate limiting and error handling tested (if applicable)
- [ ] Security considerations addressed

## Testing
I used the MCP in windsurf. I did not specifically try to update a task, I was happy it could read some.

## Documentation Updates
<!-- List any documentation updates needed -->

## Screenshots (if applicable)

<img width="688" alt="image" src="https://github.com/user-attachments/assets/46a1eea6-44ad-4040-904d-459d529cec06" />

## Additional Notes
<!-- Any additional information that might be helpful for reviewers -->
