### PR TITLE
feat: Allow disabling commands via DISABLED_COMMANDS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Or use this npx command:
 
 `npx -y @taazkareem/clickup-mcp-server@latest --env CLICKUP_API_KEY=your-api-key --env CLICKUP_TEAM_ID=your-team-id`
 
+Additionally, you can use the `DISABLED_COMMANDS` environment variable or `--env DISABLED_COMMANDS` argument to disable specific commands. Provide a comma-separated list of command names to disable (e.g., `create_task,delete_task`).
+
 ## Features
 
 | 📝 Task Management | 🏷️ Tag Management |

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ for (let i = 0; i < args.length; i++) {
     if (key === 'CLICKUP_API_KEY') envArgs.clickupApiKey = value;
     if (key === 'CLICKUP_TEAM_ID') envArgs.clickupTeamId = value;
     if (key === 'LOG_LEVEL') envArgs.logLevel = value;
+    if (key === 'DISABLED_COMMANDS') envArgs.disabledCommands = value;
     i++;
   }
 }
@@ -53,6 +54,7 @@ interface Config {
   clickupTeamId: string;
   enableSponsorMessage: boolean;
   logLevel: LogLevel;
+  disabledCommands: string[];
 }
 
 // Load configuration from command line args or environment variables
@@ -60,7 +62,10 @@ const configuration: Config = {
   clickupApiKey: envArgs.clickupApiKey || process.env.CLICKUP_API_KEY || '',
   clickupTeamId: envArgs.clickupTeamId || process.env.CLICKUP_TEAM_ID || '',
   enableSponsorMessage: process.env.ENABLE_SPONSOR_MESSAGE !== 'false',
-  logLevel: parseLogLevel(envArgs.logLevel || process.env.LOG_LEVEL)
+  logLevel: parseLogLevel(envArgs.logLevel || process.env.LOG_LEVEL),
+  disabledCommands: (
+    (envArgs.disabledCommands || process.env.DISABLED_COMMANDS)?.split(',').map(cmd => cmd.trim()).filter(cmd => cmd !== '') || []
+  ),
 };
 
 // Don't log to console as it interferes with JSON-RPC communication

--- a/src/server.ts
+++ b/src/server.ts
@@ -143,7 +143,7 @@ export function configureServer() {
         getSpaceTagsTool,
         addTagToTaskTool,
         removeTagFromTaskTool
-      ]
+      ].filter(tool => !config.disabledCommands.includes(tool.name))
     };
   });
 
@@ -166,6 +166,15 @@ export function configureServer() {
     logger.info(`Received CallTool request for tool: ${name}`, { 
       params 
     });
+    
+    // Check if the command is disabled
+    if (config.disabledCommands.includes(name)) {
+      logger.warn(`Tool execution blocked: Tool '${name}' is disabled.`);
+      throw {
+        code: -32601,
+        message: `Tool '${name}' is disabled.`
+      };
+    }
     
     try {
       // Handle tool calls by routing to the appropriate handler


### PR DESCRIPTION
Implement functionality to disable specific tools by listing their names in the DISABLED_COMMANDS environment variable.

Updates:
- README.md: Added documentation for the new environment variable.
- src/config.ts: Added parsing for DISABLED_COMMANDS.
- src/server.ts: Filter tools and check against disabled list before execution.

# Pull Request

## Description
This Pull Request adds the ability to disable specific MCP Server commands (tools) using the `DISABLED_COMMANDS` environment variable. Users can provide a comma-separated list of command names to limit the available server functionality. This provides greater flexibility in configuring the server and controlling available actions.

## Related Issue
<!-- Link to the issue this PR addresses (if applicable) -->
Fixes #

## Type of Change
- [x] Tool functionality (new tool, tool modification)
- [x] MCP integration improvement - *Improves integration by controlling tool availability*
- [ ] Bug fix
- [ ] Performance optimization
- [x] Documentation update
- [ ] API enhancements 
- [ ] Security improvement - *Indirectly, by allowing restriction of potentially sensitive commands*

## MCP Server Impact
The primary impact on server behavior is that commands listed in the `DISABLED_COMMANDS` environment variable will not be registered when the server starts. If a client attempts to call a disabled command, the server will return an error with a corresponding message.

## API Changes
There are no changes to the ClickUp API calls themselves or the logic for interacting with them at the Service layer. The changes affect the tool registration and handling layer in `src/server.ts`, where the list of available tools is filtered before being passed to the protocol, and a check for disabled commands is added upon invocation.

## Checklist
<!-- Mark the items you've completed with an "x" -->
- [x] My code follows the code style of this project
- [x] I have tested the changes
- [x] I've verified compatibility with MCP standards
- [x] All tool schemas are properly documented
- [x] Service layer changes are backward compatible (or documented if breaking)
- [ ] Rate limiting and error handling tested (if applicable)
- [ ] Security considerations addressed <!-- Indirectly addressed by the ability to restrict dangerous commands -->

## Testing
To test these changes:
1. Build the project with the changes included.
2. Run the server, setting the `DISABLED_COMMANDS` environment variable with a list of commands to disable (e.g., `DISABLED_COMMANDS=delete_task,delete_bulk_tasks`).
3. Verify that the disabled commands do not appear as available in the MCP client (if the client supports such display).
4. Attempt to call one of the disabled commands through the MCP client. Verify that the server returns an error indicating that the command is disabled.
5. Attempt to call a command that was *not* disabled to ensure it functions correctly.

## Documentation Updates
Documentation has been updated in the `README.md` file with a description of the new `DISABLED_COMMANDS` environment variable and an example of its usage.

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
This change provides administrators with a simple way to restrict MCP Server functionality without needing to modify the source code.
